### PR TITLE
Set title of widgets

### DIFF
--- a/field/url.php
+++ b/field/url.php
@@ -10,29 +10,29 @@ class midgardmvc_helper_forms_field_url extends midgardmvc_helper_forms_field_te
 
     public function validate()
     {
-        parent::__validate();
+        parent::validate();
         // if value is NOT required and it is left empy, validate as true
         if (isset($this->required) && $this->required == false && mb_strlen($this->value) == 0)
         {
             return;
-        }            
+        }
         if (filter_var($this->value, FILTER_VALIDATE_URL, FILTER_FLAG_SCHEME_REQUIRED) == false)
         {
             $message = $this->mvc->i18n->get('The field is not a valid url', "midgardmvc_helper_forms");
-            throw new midgardmvc_helper_forms_exception_validation($message); 
+            throw new midgardmvc_helper_forms_exception_validation($message);
         }
     }
 
     public function clean()
-    {    
-        parent::__clean();
+    {
+        parent::clean();
         //add http:// if missing
         if (substr($this->value, 0, 7) != 'http://')
         {
             $this->value = 'http://'.$this->value;
         }
     }
-        
+
 }
 
 ?>

--- a/widget.php
+++ b/widget.php
@@ -10,7 +10,8 @@ abstract class midgardmvc_helper_forms_widget
     protected $field;
     protected $label = '';
     protected $placeholder = '';
-        
+    protected $title = '';
+
     public function __construct(midgardmvc_helper_forms_field $field)
     {
         $this->field = $field;
@@ -22,10 +23,18 @@ abstract class midgardmvc_helper_forms_widget
     {
         $this->label = $label;
     }
-    
+
     public function set_placeholder($placeholder)
     {
         $this->placeholder = $placeholder;
+    }
+
+    /**
+     * Sets the title attribute of the widget
+     */
+    public function set_title($title)
+    {
+        $this->title = $title;
     }
 
     public function add_label($form_field)
@@ -34,14 +43,14 @@ abstract class midgardmvc_helper_forms_widget
         {
             return $form_field;
         }
-        
+
         return "<label>{$this->label}{$form_field}</label>";
     }
 
     public function get_attributes()
     {
         $attributes = array();
-        
+
         if ($this->field->required)
         {
             $attributes[] = 'required=\'required\'';
@@ -56,8 +65,14 @@ abstract class midgardmvc_helper_forms_widget
         {
             $attributes[] = "placeholder='" . str_replace("'", '’', $this->placeholder) . "'";
         }
-        
+
+        if ($this->title)
+        {
+            $attributes[] = "title='" . str_replace("'", '’', $this->title) . "'";
+        }
+
         return implode(' ', $attributes);
     }
+
 }
 ?>


### PR DESCRIPTION
The title attribute is useful to display hints in HTML forms. Can be used with JS to have fancy tooltips and therefore help the users to fill in data. This change would be very useful in the com_meego_devprogram component. 

The changes should not affect existing applications.
