### PR TITLE
Possibility to set localized labels to widgets created from mgdschemas

### DIFF
--- a/mgdschema.php
+++ b/mgdschema.php
@@ -7,10 +7,13 @@
  */
 class midgardmvc_helper_forms_mgdschema
 {
+    private static $i18n_prefix = '';
     private static $reflectionproperties = array();
 
-    public static function create(midgard_object $object, $include_metadata = true)
+    public static function create(midgard_object $object, $include_metadata = true, $i18n_prefix = '')
     {
+        self::$i18n_prefix = $i18n_prefix;
+
         $form_namespace = get_class($object);
         if ($object->guid)
         {
@@ -24,6 +27,9 @@ class midgardmvc_helper_forms_mgdschema
 
     public static function object_to_form($object, midgardmvc_helper_forms_group $form, $include_metadata = true)
     {
+        // Get the mvc instance for fetching i18n strings
+        $mvc = midgardmvc_core::get_instance();
+
         // Go through object properties
         $props = get_object_vars($object);
         foreach ($props as $property => $value)
@@ -33,12 +39,17 @@ class midgardmvc_helper_forms_mgdschema
             {
                 continue;
             }
-            self::property_to_form(get_class($object), $property, $value, $form);
+            self::property_to_form(get_class($object), $property, $value, $form, null, $mvc->i18n->get(self::$i18n_prefix . $property));
         }
     }
 
-    public static function property_to_form($class, $property, $value, midgardmvc_helper_forms_group $form, $fieldname = null)
+    public static function property_to_form($class, $property, $value, midgardmvc_helper_forms_group $form, $fieldname = null, $label = null)
     {
+        if (is_null($label))
+        {
+            $label = $propery;
+        }
+
         if (is_null($fieldname))
         {
             $fieldname = $property;
@@ -81,7 +92,7 @@ class midgardmvc_helper_forms_mgdschema
                 $field->set_value($value);
                 $field->set_inline(true);
                 $widget = $field->set_widget('text');
-                $widget->set_label($property);
+                $widget->set_label($label);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 // TODO: maxlength to 255
                 break;
@@ -97,14 +108,14 @@ class midgardmvc_helper_forms_mgdschema
                     $widget = $field->set_widget('textarea');
                 }
                 $field->set_value($value);
-                $widget->set_label($property);
+                $widget->set_label($label);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_INT:
                 $field = $form->add_field($fieldname, 'integer', $required);
                 $field->set_value($value);
                 $widget = $field->set_widget('number');
-                $widget->set_label($property);
+                $widget->set_label($label);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_UINT:
@@ -112,7 +123,7 @@ class midgardmvc_helper_forms_mgdschema
                 $field->set_value($value);
                 // TODO: Set minimum value to 0
                 $widget = $field->set_widget('number');
-                $widget->set_label($property);
+                $widget->set_label($label);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_BOOLEAN:
@@ -123,14 +134,14 @@ class midgardmvc_helper_forms_mgdschema
                 $field = $form->add_field($fieldname, 'float', $required);
                 $field->set_value($value);
                 $widget = $field->set_widget('number');
-                $widget->set_label($property);
+                $widget->set_label($label);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_TIMESTAMP:
                 $field = $form->add_field($fieldname, 'datetime', $required);
                 $field->set_value($value);
                 $widget = $field->set_widget('datetime');
-                $widget->set_label($property);
+                $widget->set_label($label);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
             case MGD_TYPE_GUID:
                 break;


### PR DESCRIPTION
This patch is again not harmful for existing applications, but enables us to use a i18n_prefix when requesting a form:

   $this->form = midgardmvc_helper_forms_mgdschema::create($this->object, false, 'label_device_');

Using the prefix we can define localized strings for the labels.

If a property is called 'name', and we have the localization prefix: 'label_device_', then midgardmvc_helper_forms_mgdschema will lookup the 'label_device_name' string and will use it in the generated html. 

If there is no localization prefix givn when creating the form, then we will revert to use the property names as it was before.

Again this patch would reduce code in many places and enables i18n in forms.
