### PR TITLE
Enable to set different class and label to default submit button

### DIFF
--- a/form.php
+++ b/form.php
@@ -83,13 +83,19 @@ class midgardmvc_helper_forms_form extends midgardmvc_helper_forms_group
      * using the class definition for CSS
      * and the label for the value attirbute
      */
-    public function set_submit($class = null, $label = '')
+    public function set_submit($class = null, $label = '', $disabled = null)
     {
         if (is_null($class))
         {
             $class = "midgardmvc_helper_forms_form_save";
         }
-        $this->submit = "<input type='submit' class='{$class}' value='{$label}' />\n";
+
+        if ($disabled)
+        {
+            $disabled = 'disabled="disabled"';
+        }
+
+        $this->submit = "<input type='submit' class='{$class}' value='{$label}' {$disabled}/>\n";
     }
 
     public function __toString()

--- a/form.php
+++ b/form.php
@@ -11,11 +11,13 @@ class midgardmvc_helper_forms_form extends midgardmvc_helper_forms_group
     private $post_processed = false;
     private $action = '';
     private $method = 'post';
+    private $submit = '';
 
     public function __construct($form_namespace)
     {
         $this->mvc = midgardmvc_core::get_instance();
         parent::__construct($form_namespace);
+        $this->set_submit(null, $this->mvc->i18n->get('save', 'midgardmvc_helper_forms'));
     }
 
     public function __get($key)
@@ -25,12 +27,12 @@ class midgardmvc_helper_forms_form extends midgardmvc_helper_forms_group
             && !$this->post_processed)
         {
             // TODO: Process??
-        }      
+        }
         if ($key == 'namespace')
         {
             return parent::__get('name');
         }
-        
+
         return parent::__get($key);
     }
 
@@ -65,7 +67,7 @@ class midgardmvc_helper_forms_form extends midgardmvc_helper_forms_group
         }
         $mvc->sessioning->set('midgardmvc_helper_forms', "stored_{$this->namespace}", $stored);
     }
-    
+
     public function clean_store()
     {
         $mvc = midgardmvc_core::get_instance();
@@ -75,7 +77,21 @@ class midgardmvc_helper_forms_form extends midgardmvc_helper_forms_group
         }
         $mvc->sessioning->remove('midgardmvc_helper_forms', "stored_{$this->namespace}");
     }
-    
+
+    /**
+     * Sets the submit button of the form
+     * using the class definition for CSS
+     * and the label for the value attirbute
+     */
+    public function set_submit($class = null, $label = '')
+    {
+        if (is_null($class))
+        {
+            $class = "midgardmvc_helper_forms_form_save";
+        }
+        $this->submit = "<input type='submit' class='{$class}' value='{$label}' />\n";
+    }
+
     public function __toString()
     {
         $form_string  = "<form method='{$this->method}' action='{$this->action}'>\n";
@@ -87,13 +103,13 @@ class midgardmvc_helper_forms_form extends midgardmvc_helper_forms_group
                 $form_string .= $item;
                 continue;
             }
+
             $form_string .= $item->widget;
         }
 
         if (!$this->readonly)
         {
-            $label = midgardmvc_core::get_instance()->i18n->get('save', 'midgardmvc_helper_forms');
-            $form_string .= "<input type='submit' class='midgardmvc_helper_forms_form_save' value='{$label}' />\n";
+            $form_string .= $this->submit;
         }
 
         $form_string .= "</form>\n";

--- a/mgdschema.php
+++ b/mgdschema.php
@@ -8,11 +8,13 @@
 class midgardmvc_helper_forms_mgdschema
 {
     private static $i18n_prefix = '';
+    private static $i18n_tip_prefix = 'tip_';
     private static $reflectionproperties = array();
 
-    public static function create(midgard_object $object, $include_metadata = true, $i18n_prefix = '')
+    public static function create(midgard_object $object, $include_metadata = true, $i18n_prefix = '', $i18n_tip_prefix = '')
     {
         self::$i18n_prefix = $i18n_prefix;
+        self::$i18n_tip_prefix = $i18n_tip_prefix;
 
         $form_namespace = get_class($object);
         if ($object->guid)
@@ -39,11 +41,11 @@ class midgardmvc_helper_forms_mgdschema
             {
                 continue;
             }
-            self::property_to_form(get_class($object), $property, $value, $form, null, $mvc->i18n->get(self::$i18n_prefix . $property));
+            self::property_to_form(get_class($object), $property, $value, $form, null, $mvc->i18n->get(self::$i18n_prefix . $property), $mvc->i18n->get(self::$i18n_tip_prefix . $property));
         }
     }
 
-    public static function property_to_form($class, $property, $value, midgardmvc_helper_forms_group $form, $fieldname = null, $label = null)
+    public static function property_to_form($class, $property, $value, midgardmvc_helper_forms_group $form, $fieldname = null, $label = null, $tip = null)
     {
         if (is_null($label))
         {
@@ -93,6 +95,7 @@ class midgardmvc_helper_forms_mgdschema
                 $field->set_inline(true);
                 $widget = $field->set_widget('text');
                 $widget->set_label($label);
+                $widget->set_title($tip);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 // TODO: maxlength to 255
                 break;
@@ -109,6 +112,7 @@ class midgardmvc_helper_forms_mgdschema
                 }
                 $field->set_value($value);
                 $widget->set_label($label);
+                $widget->set_title($tip);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_INT:
@@ -116,6 +120,7 @@ class midgardmvc_helper_forms_mgdschema
                 $field->set_value($value);
                 $widget = $field->set_widget('number');
                 $widget->set_label($label);
+                $widget->set_title($tip);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_UINT:
@@ -124,6 +129,7 @@ class midgardmvc_helper_forms_mgdschema
                 // TODO: Set minimum value to 0
                 $widget = $field->set_widget('number');
                 $widget->set_label($label);
+                $widget->set_title($tip);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_BOOLEAN:
@@ -135,6 +141,7 @@ class midgardmvc_helper_forms_mgdschema
                 $field->set_value($value);
                 $widget = $field->set_widget('number');
                 $widget->set_label($label);
+                $widget->set_title($tip);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_TIMESTAMP:
@@ -142,6 +149,7 @@ class midgardmvc_helper_forms_mgdschema
                 $field->set_value($value);
                 $widget = $field->set_widget('datetime');
                 $widget->set_label($label);
+                $widget->set_title($tip);
                 $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
             case MGD_TYPE_GUID:
                 break;

--- a/mgdschema.php
+++ b/mgdschema.php
@@ -135,6 +135,10 @@ class midgardmvc_helper_forms_mgdschema
             case MGD_TYPE_BOOLEAN:
                 $field = $form->add_field($fieldname, 'boolean', $required);
                 $field->set_value($value);
+                $widget = $field->set_widget('checkbox');
+                $widget->set_label($label);
+                $widget->set_title($tip);
+                $widget->set_placeholder(self::$reflectionproperties[$class]->description($property));
                 break;
             case MGD_TYPE_FLOAT:
                 $field = $form->add_field($fieldname, 'float', $required);

--- a/widget.php
+++ b/widget.php
@@ -11,6 +11,7 @@ abstract class midgardmvc_helper_forms_widget
     protected $label = '';
     protected $placeholder = '';
     protected $title = '';
+    protected $css = '';
 
     public function __construct(midgardmvc_helper_forms_field $field)
     {
@@ -35,6 +36,14 @@ abstract class midgardmvc_helper_forms_widget
     public function set_title($title)
     {
         $this->title = $title;
+    }
+
+    /**
+     * Sets the CSS class attribute of the widget
+     */
+    public function set_css($css)
+    {
+        $this->css = $css;
     }
 
     public function add_label($form_field)
@@ -69,6 +78,11 @@ abstract class midgardmvc_helper_forms_widget
         if ($this->title)
         {
             $attributes[] = "title='" . str_replace("'", '’', $this->title) . "'";
+        }
+
+        if ($this->css)
+        {
+            $attributes[] = "class='" . str_replace("'", '’', $this->css) . "'";
         }
 
         return implode(' ', $attributes);

--- a/widget/radiobuttons.php
+++ b/widget/radiobuttons.php
@@ -23,7 +23,7 @@ class midgardmvc_helper_forms_widget_radiobuttons extends midgardmvc_helper_form
                 throw new Exception("Invalid options array");
             }
         }
-    
+
     }
 
     public function add_option($description, $value)
@@ -35,8 +35,8 @@ class midgardmvc_helper_forms_widget_radiobuttons extends midgardmvc_helper_form
     }
 
     public function __toString()
-    {   
-        $output = '<ul>';
+    {
+        $output = '<ul class="' . $this->field->get_name() . '">';
         foreach($this->options as $o)
         {
             $output .= "<li><input type='radio' name='{$this->field->get_name()}' value='".$o['value']."' {$this->get_attributes()}";


### PR DESCRIPTION
Again a harmless patch that makes form customization easier. Once a form is created one could set the class and label of its submit button:

```
    $this->form = midgardmvc_helper_forms_mgdschema::create($this->object, false, 'label_device_');
    $this->form->set_submit('form_submit', $this->mvc->i18n->get('command_save'));
```

Naturally if set_submit() is not called, then the current defaults will be used.
