### PR TITLE
Minor things

### DIFF
--- a/widget.php
+++ b/widget.php
@@ -20,6 +20,11 @@ abstract class midgardmvc_helper_forms_widget
 
     public abstract function __toString();
 
+    public function get_label()
+    {
+        return $this->label;
+    }
+
     public function set_label($label)
     {
         $this->label = $label;

--- a/widget/checkbox.php
+++ b/widget/checkbox.php
@@ -16,7 +16,7 @@ class midgardmvc_helper_forms_widget_checkbox extends midgardmvc_helper_forms_wi
     }
 
     public function __toString()
-    {   
+    {
         $output = "<span><input type='checkbox' name='{$this->field->get_name()}' id='{$this->field->get_name()}' value='1' {$this->get_attributes()}";
         if ($this->field->get_value() == true)
         {
@@ -28,6 +28,8 @@ class midgardmvc_helper_forms_widget_checkbox extends midgardmvc_helper_forms_wi
         {
             $output .= "<label for='{$this->field->get_name()}'>{$this->label}</label>";
         }
+
+        $output .= "</span>";
 
         return $output;
     }


### PR DESCRIPTION
We need a closing tag to the checkbox span. I added that long time ago (in April).

The "label" property of a "widget" is protected. , so I wrote a simple getter. It will be used in midgardmvc_ui_forms to set management related links (edit and delete) into the label. These links can be styled then (e.g. having a background image). See my other pull requests for that component. 

These would be essential for MeeGo Apps.
